### PR TITLE
Feature/validated groups

### DIFF
--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/Validators.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/Validators.java
@@ -18,6 +18,7 @@
  */
 package springfox.bean.validators.plugins;
 
+import com.fasterxml.classmate.ResolvedType;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.AnnotationUtils;
@@ -29,7 +30,10 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 
 import static java.util.Optional.*;
 
@@ -100,5 +104,21 @@ public class Validators {
       Class<T> annotationType) {
     return annotatedElement
         .map(annotated -> AnnotationUtils.findAnnotation(annotated, annotationType));
+  }
+
+  public static boolean existsIntersectionBetweenValidationGroups(ModelPropertyContext context,
+                                                                  Class<?>[] groupsAnnotationArray) {
+
+    Set<ResolvedType> groupsInValidatedAnnotation = context.getOwner().getValidationGroups();
+    if (groupsInValidatedAnnotation.isEmpty()) {
+      return true;
+    }
+
+    Set<Class<?>> groupsIsConstraintAnnotation = new HashSet<>(Arrays.asList(groupsAnnotationArray));
+    if (groupsIsConstraintAnnotation.isEmpty()) {
+      return true;
+    }
+
+    return groupsInValidatedAnnotation.stream().anyMatch(i -> groupsIsConstraintAnnotation.contains(i.getErasedType()));
   }
 }

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/DecimalMinMaxAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/DecimalMinMaxAnnotationPlugin.java
@@ -58,6 +58,14 @@ public class DecimalMinMaxAnnotationPlugin implements ModelPropertyBuilderPlugin
     Optional<DecimalMin> min = extractAnnotation(context, DecimalMin.class);
     Optional<DecimalMax> max = extractAnnotation(context, DecimalMax.class);
 
+    if (min.isPresent() && !mustBeAppliedAccordingToValidationGroups(context, min.get())) {
+      min = Optional.empty();
+    }
+
+    if (max.isPresent() && !mustBeAppliedAccordingToValidationGroups(context, max.get())) {
+      max = Optional.empty();
+    }
+
     // add support for @DecimalMin/@DecimalMax
     Compatibility<AllowableValues, NumericElementFacet> values =
         facetFromDecimalMinMaxForNumbers(min, max);
@@ -115,4 +123,11 @@ public class DecimalMinMaxAnnotationPlugin implements ModelPropertyBuilderPlugin
     return new Compatibility<>(myvalues, numericFacet);
   }
 
+  private boolean mustBeAppliedAccordingToValidationGroups(ModelPropertyContext context, DecimalMax max) {
+    return Validators.existsIntersectionBetweenValidationGroups(context, max.groups());
+  }
+
+  private boolean mustBeAppliedAccordingToValidationGroups(ModelPropertyContext context, DecimalMin min) {
+    return Validators.existsIntersectionBetweenValidationGroups(context, min.groups());
+  }
 }

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/IsNullAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/IsNullAnnotationPlugin.java
@@ -21,6 +21,7 @@ package springfox.bean.validators.plugins.schema;
 
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
+import springfox.bean.validators.plugins.Validators;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.schema.ModelPropertyBuilderPlugin;
 import springfox.documentation.spi.schema.contexts.ModelPropertyContext;
@@ -49,12 +50,16 @@ public class IsNullAnnotationPlugin implements ModelPropertyBuilderPlugin {
   @Override
   public void apply(ModelPropertyContext context) {
     Optional<Null> isNull = extractAnnotation(context);
-    if (isNull.isPresent()) {
-      context.getBuilder().readOnly(isNull.isPresent());
+    if (isNull.isPresent() && mustBeAppliedAccordingToValidationGroups(context, isNull.get())) {
+      context.getBuilder().readOnly(true);
     }
   }
 
   private Optional<Null> extractAnnotation(ModelPropertyContext context) {
     return annotationFromBean(context, Null.class).map(Optional::of).orElse(annotationFromField(context, Null.class));
+  }
+
+  private boolean mustBeAppliedAccordingToValidationGroups(ModelPropertyContext context, Null isNull) {
+    return Validators.existsIntersectionBetweenValidationGroups(context, isNull.groups());
   }
 }

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/MinMaxAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/MinMaxAnnotationPlugin.java
@@ -55,6 +55,14 @@ public class MinMaxAnnotationPlugin implements ModelPropertyBuilderPlugin {
     Optional<Min> min = extractMin(context);
     Optional<Max> max = extractMax(context);
 
+    if (min.isPresent() && !mustBeAppliedAccordingToValidationGroups(context, min.get())) {
+      min = Optional.empty();
+    }
+
+    if (max.isPresent() && !mustBeAppliedAccordingToValidationGroups(context, max.get())) {
+      max = Optional.empty();
+    }
+
     // add support for @Min/@Max
     Compatibility<AllowableRangeValues, NumericElementFacet> values = allowableRange(min, max);
     LOGGER.debug(String.format(
@@ -79,5 +87,13 @@ public class MinMaxAnnotationPlugin implements ModelPropertyBuilderPlugin {
 
   private Optional<Max> extractMax(ModelPropertyContext context) {
     return annotationFromBean(context, Max.class).map(Optional::of).orElse(annotationFromField(context, Max.class));
+  }
+
+  public static boolean mustBeAppliedAccordingToValidationGroups(ModelPropertyContext context, Max max) {
+    return Validators.existsIntersectionBetweenValidationGroups(context, max.groups());
+  }
+
+  public static boolean mustBeAppliedAccordingToValidationGroups(ModelPropertyContext context, Min min) {
+    return Validators.existsIntersectionBetweenValidationGroups(context, min.groups());
   }
 }

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/NotBlankAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/NotBlankAnnotationPlugin.java
@@ -52,7 +52,7 @@ public class NotBlankAnnotationPlugin implements ModelPropertyBuilderPlugin {
   @SuppressWarnings("deprecation")
   public void apply(ModelPropertyContext context) {
     Optional<NotBlank> notBlank = extractAnnotation(context);
-    if (notBlank.isPresent()) {
+    if (notBlank.isPresent() && mustBeAppliedAccordingToValidationGroups(context, notBlank.get())) {
       context.getBuilder().required(true);
       context.getSpecificationBuilder().required(true);
     }
@@ -62,5 +62,9 @@ public class NotBlankAnnotationPlugin implements ModelPropertyBuilderPlugin {
     return annotationFromBean(context, NotBlank.class)
         .map(Optional::of)
         .orElse(annotationFromField(context, NotBlank.class));
+  }
+
+  private boolean mustBeAppliedAccordingToValidationGroups(ModelPropertyContext context, NotBlank notBlank) {
+    return Validators.existsIntersectionBetweenValidationGroups(context, notBlank.groups());
   }
 }

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/NotNullAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/NotNullAnnotationPlugin.java
@@ -51,7 +51,7 @@ public class NotNullAnnotationPlugin implements ModelPropertyBuilderPlugin {
   @SuppressWarnings("deprecation")
   public void apply(ModelPropertyContext context) {
     Optional<NotNull> notNull = extractAnnotation(context);
-    if (notNull.isPresent()) {
+    if (notNull.isPresent() && mustBeAppliedAccordingToValidationGroups(context, notNull.get())) {
       context.getBuilder().required(true);
       context.getSpecificationBuilder().required(true);
     }
@@ -61,5 +61,9 @@ public class NotNullAnnotationPlugin implements ModelPropertyBuilderPlugin {
     return annotationFromBean(context, NotNull.class)
         .map(Optional::of)
         .orElse(annotationFromField(context, NotNull.class));
+  }
+
+  private boolean mustBeAppliedAccordingToValidationGroups(ModelPropertyContext context, NotNull notNull) {
+    return Validators.existsIntersectionBetweenValidationGroups(context, notNull.groups());
   }
 }

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/PatternAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/PatternAnnotationPlugin.java
@@ -39,6 +39,10 @@ public class PatternAnnotationPlugin implements ModelPropertyBuilderPlugin {
   @SuppressWarnings("deprecation")
   public void apply(ModelPropertyContext context) {
     Optional<Pattern> pattern = extractAnnotation(context, Pattern.class);
+    if (pattern.isPresent() && !mustBeAppliedAccordingToValidationGroups(context, pattern.get())) {
+      pattern = Optional.empty();
+    }
+
     String patternValueFromAnnotation = createPatternValueFromAnnotation(pattern);
     context.getBuilder().pattern(patternValueFromAnnotation);
     if (patternValueFromAnnotation != null) {
@@ -58,5 +62,9 @@ public class PatternAnnotationPlugin implements ModelPropertyBuilderPlugin {
       patternValue = pattern.get().regexp();
     }
     return patternValue;
+  }
+
+  private boolean mustBeAppliedAccordingToValidationGroups(ModelPropertyContext context, Pattern pattern) {
+    return Validators.existsIntersectionBetweenValidationGroups(context, pattern.groups());
   }
 }

--- a/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/SizeAnnotationPlugin.java
+++ b/springfox-bean-validators/src/main/java/springfox/bean/validators/plugins/schema/SizeAnnotationPlugin.java
@@ -47,6 +47,9 @@ public class SizeAnnotationPlugin implements ModelPropertyBuilderPlugin {
   @SuppressWarnings("deprecation")
   public void apply(ModelPropertyContext context) {
     Optional<Size> size = extractAnnotation(context);
+    if (size.isPresent() && !mustBeAppliedAccordingToValidationGroups(context, size.get())) {
+      size = Optional.empty();
+    }
 
     size.ifPresent(size1 -> {
       AllowableRangeValues allowableRangeValues = stringLengthRange(size1);
@@ -70,5 +73,9 @@ public class SizeAnnotationPlugin implements ModelPropertyBuilderPlugin {
 
   Optional<Size> extractAnnotation(ModelPropertyContext context) {
     return annotationFromBean(context, Size.class).map(Optional::of).orElse(annotationFromField(context, Size.class));
+  }
+
+  public static boolean mustBeAppliedAccordingToValidationGroups(ModelPropertyContext context, Size size) {
+    return Validators.existsIntersectionBetweenValidationGroups(context, size.groups());
   }
 }

--- a/springfox-oas/src/main/java/springfox/documentation/oas/mappers/SchemaMapper.java
+++ b/springfox-oas/src/main/java/springfox/documentation/oas/mappers/SchemaMapper.java
@@ -12,6 +12,7 @@ import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Named;
 import springfox.documentation.schema.CollectionElementFacet;
+import springfox.documentation.schema.CompoundModelSpecification;
 import springfox.documentation.schema.ElementFacetSource;
 import springfox.documentation.schema.EnumerationFacet;
 import springfox.documentation.schema.ModelFacets;

--- a/springfox-schema/src/main/java/springfox/documentation/schema/ValidatedProvider.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/ValidatedProvider.java
@@ -1,0 +1,102 @@
+/*
+ *
+ *  Copyright 2017 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.documentation.schema;
+
+import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.classmate.TypeResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+import springfox.documentation.service.ResolvedMethodParameter;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.schema.ValidatedProviderPlugin;
+import springfox.documentation.spi.service.contexts.OperationContext;
+import springfox.documentation.spi.service.contexts.RequestMappingContext;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Component
+@Order
+public class ValidatedProvider implements ValidatedProviderPlugin {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ValidatedProvider.class);
+
+  private final TypeResolver typeResolver;
+
+  @Autowired
+  public ValidatedProvider(TypeResolver typeResolver) {
+    this.typeResolver = typeResolver;
+  }
+
+  @Override
+  public boolean supports(DocumentationType delimiter) {
+    return true;
+  }
+
+  @Override
+  public Set<ResolvedType> validationFor(
+      ResolvedMethodParameter parameter) {
+    return validationFor(
+        String.format("Parameter name: %s @ index: %s",
+                      parameter.defaultName().orElse("<none>"),
+                      parameter.getParameterIndex()),
+        parameter.findAnnotation(Validated.class)
+                 .orElse(null));
+  }
+
+  @Override
+  public Set<ResolvedType> validationFor(
+      RequestMappingContext context) {
+    return validationFor(
+        String.format("Request Mapping: %s", context.getRequestMappingPattern()),
+        context.findAnnotation(Validated.class)
+               .orElse(null));
+  }
+
+  @Override
+  public Set<ResolvedType> validationFor(
+      OperationContext context) {
+    return validationFor(
+        String.format("Operation: %s", context.getName()),
+        context.findAnnotation(Validated.class).orElse(null));
+  }
+
+  private Set<ResolvedType> validationFor(
+      String context,
+      Validated annotation) {
+    Set<ResolvedType> resolvedTypes = new HashSet<>();
+    if (annotation != null) {
+      Class<?>[] validatedGroups = annotation.value();
+      resolvedTypes = Stream.of(validatedGroups).map(typeResolver::resolve).collect(Collectors.toSet());
+      LOG.debug(
+          "Found validation groups {} for type {}",
+          resolvedTypes.stream().map(ResolvedTypes::resolvedTypeSignature).toString(),
+          context);
+    }
+
+    return resolvedTypes;
+  }
+}

--- a/springfox-schema/src/main/java/springfox/documentation/schema/configuration/ModelsConfiguration.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/configuration/ModelsConfiguration.java
@@ -28,6 +28,7 @@ import springfox.documentation.spi.schema.ModelBuilderPlugin;
 import springfox.documentation.spi.schema.ModelPropertyBuilderPlugin;
 import springfox.documentation.spi.schema.SyntheticModelProviderPlugin;
 import springfox.documentation.spi.schema.TypeNameProviderPlugin;
+import springfox.documentation.spi.schema.ValidatedProviderPlugin;
 import springfox.documentation.spi.schema.ViewProviderPlugin;
 
 @Configuration
@@ -40,6 +41,7 @@ import springfox.documentation.spi.schema.ViewProviderPlugin;
     TypeNameProviderPlugin.class,
     SyntheticModelProviderPlugin.class,
     ViewProviderPlugin.class,
+    ValidatedProviderPlugin.class,
 })
 public class ModelsConfiguration {
   @Bean

--- a/springfox-schema/src/main/java/springfox/documentation/schema/plugins/SchemaPluginsManager.java
+++ b/springfox-schema/src/main/java/springfox/documentation/schema/plugins/SchemaPluginsManager.java
@@ -29,6 +29,7 @@ import springfox.documentation.schema.PropertySpecification;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.schema.ModelBuilderPlugin;
 import springfox.documentation.spi.schema.ModelPropertyBuilderPlugin;
+import springfox.documentation.spi.schema.ValidatedProviderPlugin;
 import springfox.documentation.spi.schema.ViewProviderPlugin;
 import springfox.documentation.spi.schema.SyntheticModelProviderPlugin;
 import springfox.documentation.spi.schema.contexts.ModelContext;
@@ -45,6 +46,7 @@ public class SchemaPluginsManager {
   private final PluginRegistry<ModelPropertyBuilderPlugin, DocumentationType> propertyEnrichers;
   private final PluginRegistry<ModelBuilderPlugin, DocumentationType> modelEnrichers;
   private final PluginRegistry<ViewProviderPlugin, DocumentationType> viewProviders;
+  private final PluginRegistry<ValidatedProviderPlugin, DocumentationType> validatedProviders;
   private final PluginRegistry<SyntheticModelProviderPlugin, ModelContext> syntheticModelProviders;
 
   @Autowired
@@ -55,11 +57,14 @@ public class SchemaPluginsManager {
           PluginRegistry<ModelBuilderPlugin, DocumentationType> modelEnrichers,
       @Qualifier("viewProviderPluginRegistry")
           PluginRegistry<ViewProviderPlugin, DocumentationType> viewProviders,
+      @Qualifier("validatedProviderPluginRegistry")
+          PluginRegistry<ValidatedProviderPlugin, DocumentationType> validatedProviders,
       @Qualifier("syntheticModelProviderPluginRegistry")
           PluginRegistry<SyntheticModelProviderPlugin, ModelContext> syntheticModelProviders) {
     this.propertyEnrichers = propertyEnrichers;
     this.modelEnrichers = modelEnrichers;
     this.viewProviders = viewProviders;
+    this.validatedProviders = validatedProviders;
     this.syntheticModelProviders = syntheticModelProviders;
   }
 
@@ -94,6 +99,11 @@ public class SchemaPluginsManager {
   public ViewProviderPlugin viewProvider(DocumentationType documentationType) {
     return viewProviders.getPluginFor(documentationType)
         .orElseThrow(() -> new IllegalStateException("No ViewProviderPlugin for " + documentationType.getName()));
+  }
+
+  public ValidatedProviderPlugin validatedProvider(DocumentationType documentationType) {
+    return validatedProviders.getPluginFor(documentationType)
+        .orElseThrow(() -> new IllegalStateException("No ValidatedProviderPlugin for " + documentationType.getName()));
   }
 
   /**

--- a/springfox-schema/src/test/groovy/springfox/documentation/schema/mixins/SchemaPluginsSupport.groovy
+++ b/springfox-schema/src/test/groovy/springfox/documentation/schema/mixins/SchemaPluginsSupport.groovy
@@ -25,6 +25,7 @@ import springfox.documentation.schema.DefaultTypeNameProvider
 import springfox.documentation.schema.JacksonEnumTypeDeterminer
 import springfox.documentation.schema.JacksonJsonViewProvider
 import springfox.documentation.schema.TypeNameExtractor
+import springfox.documentation.schema.ValidatedProvider
 import springfox.documentation.schema.plugins.PropertyDiscriminatorBasedInheritancePlugin
 import springfox.documentation.schema.plugins.SchemaPluginsManager
 import springfox.documentation.schema.property.ModelSpecificationFactory
@@ -33,6 +34,7 @@ import springfox.documentation.spi.schema.ModelBuilderPlugin
 import springfox.documentation.spi.schema.ModelPropertyBuilderPlugin
 import springfox.documentation.spi.schema.SyntheticModelProviderPlugin
 import springfox.documentation.spi.schema.TypeNameProviderPlugin
+import springfox.documentation.spi.schema.ValidatedProviderPlugin
 import springfox.documentation.spi.schema.ViewProviderPlugin
 import springfox.documentation.spi.schema.contexts.ModelContext
 
@@ -62,9 +64,12 @@ trait SchemaPluginsSupport {
     PluginRegistry<ViewProviderPlugin, DocumentationType> viewProviderRegistry =
         OrderAwarePluginRegistry.of([new JacksonJsonViewProvider(new TypeResolver())])
 
+    PluginRegistry<ValidatedProviderPlugin, DocumentationType> validatedProviderRegistry =
+        OrderAwarePluginRegistry.of([new ValidatedProvider(new TypeResolver())])
+
     PluginRegistry<SyntheticModelProviderPlugin, ModelContext> syntheticModelRegistry =
         OrderAwarePluginRegistry.of(new ArrayList<>())
 
-    new SchemaPluginsManager(propRegistry, modelRegistry, viewProviderRegistry, syntheticModelRegistry)
+    new SchemaPluginsManager(propRegistry, modelRegistry, viewProviderRegistry, validatedProviderRegistry, syntheticModelRegistry)
   }
 }

--- a/springfox-spi/src/main/java/springfox/documentation/spi/schema/ValidatedProviderPlugin.java
+++ b/springfox-spi/src/main/java/springfox/documentation/spi/schema/ValidatedProviderPlugin.java
@@ -1,0 +1,51 @@
+/*
+ *
+ *  Copyright 2017 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package springfox.documentation.spi.schema;
+
+import com.fasterxml.classmate.ResolvedType;
+import org.springframework.plugin.core.Plugin;
+import springfox.documentation.service.ResolvedMethodParameter;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.OperationContext;
+import springfox.documentation.spi.service.contexts.RequestMappingContext;
+
+import java.util.Set;
+
+public interface ValidatedProviderPlugin extends Plugin<DocumentationType> {
+
+  /**
+   * Finds active validations for the parameter type
+   * @param parameter - resolved method parameter to take additional information from, if needed
+   */
+  Set<ResolvedType> validationFor(ResolvedMethodParameter parameter);
+
+  /**
+   * Finds active validations for the parameter type
+   * @param context - method context to take additional information from, if needed
+   */
+  Set<ResolvedType> validationFor(RequestMappingContext context);
+
+  /**
+   * Finds active validations for the return type
+   * @param context - operation context to take additional information from, if needed
+   */
+  Set<ResolvedType> validationFor(OperationContext context);
+
+}

--- a/springfox-spi/src/main/java/springfox/documentation/spi/schema/contexts/ModelContext.java
+++ b/springfox-spi/src/main/java/springfox/documentation/spi/schema/contexts/ModelContext.java
@@ -262,6 +262,44 @@ public class ModelContext {
   }
 
   /**
+   * Convenience method to provide an new context for an return parameter
+   *
+   * @param parameterId           - parameter id
+   * @param groupName             - group name of the docket
+   * @param type                  - type
+   * @param view                  - view
+   * @param documentationType     - for documentation type
+   * @param alternateTypeProvider - alternate type provider
+   * @param genericNamingStrategy - how generic types should be named
+   * @param ignorableTypes        - types that can be ignored
+   * @return new context
+   */
+  @SuppressWarnings("ParameterNumber")
+  public static ModelContext returnValue(
+          String parameterId,
+          String groupName,
+          ResolvedType type,
+          Optional<ResolvedType> view,
+          DocumentationType documentationType,
+          AlternateTypeProvider alternateTypeProvider,
+          GenericTypeNamingStrategy genericNamingStrategy,
+          Set<Class> ignorableTypes,
+          Set<ResolvedType> validationGroups) {
+
+    return new ModelContext(
+            parameterId,
+            groupName,
+            type,
+            true,
+            view,
+            validationGroups,
+            documentationType,
+            alternateTypeProvider,
+            genericNamingStrategy,
+            ignorableTypes);
+  }
+
+  /**
    * Convenience method to provide an new context for an input parameter
    *
    * @param context - parent context

--- a/springfox-spi/src/main/java/springfox/documentation/spi/service/contexts/OperationModelContextsBuilder.java
+++ b/springfox-spi/src/main/java/springfox/documentation/spi/service/contexts/OperationModelContextsBuilder.java
@@ -66,6 +66,10 @@ public class OperationModelContextsBuilder {
   }
 
   public ModelContext addReturn(ResolvedType type, Optional<ResolvedType> view) {
+    return addReturn(type, view, new HashSet<>());
+  }
+
+  public ModelContext addReturn(ResolvedType type, Optional<ResolvedType> view, Set<ResolvedType> validationGroups) {
     ModelContext returnValue = ModelContext.returnValue(
         String.format("%s_%s", requestMappingId, parameterIndex),
         group,
@@ -74,7 +78,8 @@ public class OperationModelContextsBuilder {
         documentationType,
         alternateTypeProvider,
         genericsNamingStrategy,
-        ignorableTypes);
+        ignorableTypes,
+        validationGroups);
     if (this.contexts.add(returnValue)) {
       ++parameterIndex;
       return returnValue;

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/OperationModelsProvider.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/OperationModelsProvider.java
@@ -31,6 +31,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import springfox.documentation.schema.plugins.SchemaPluginsManager;
 import springfox.documentation.service.ResolvedMethodParameter;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.schema.ValidatedProviderPlugin;
 import springfox.documentation.spi.schema.ViewProviderPlugin;
 import springfox.documentation.spi.service.OperationModelsProviderPlugin;
 import springfox.documentation.spi.service.contexts.RequestMappingContext;
@@ -38,6 +39,7 @@ import springfox.documentation.spi.service.contexts.RequestMappingContext;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static springfox.documentation.schema.ResolvedTypes.*;
 
@@ -82,7 +84,8 @@ public class OperationModelsProvider implements OperationModelsProviderPlugin {
     context.operationModelsBuilder()
            .addReturn(
                modelType,
-               viewForReturn(context));
+               viewForReturn(context),
+                   validatedForReturn(context));
   }
 
   private void collectParameters(RequestMappingContext context) {
@@ -103,7 +106,7 @@ public class OperationModelsProvider implements OperationModelsProviderPlugin {
             viewForParameter(
                 context,
                 parameterType),
-            new HashSet<>());
+                validatedForParameter(context, parameterType));
       }
     }
     LOG.debug(
@@ -125,5 +128,20 @@ public class OperationModelsProvider implements OperationModelsProviderPlugin {
         pluginsManager.viewProvider(context.getDocumentationContext().getDocumentationType());
     return viewProvider.viewFor(
         parameter);
+  }
+
+  private Set<ResolvedType> validatedForReturn(RequestMappingContext context) {
+    ValidatedProviderPlugin validatedProviderPlugin =
+        pluginsManager.validatedProvider(context.getDocumentationContext().getDocumentationType());
+    return validatedProviderPlugin.validationFor(context);
+  }
+
+  private Set<ResolvedType> validatedForParameter(
+     RequestMappingContext context,
+     ResolvedMethodParameter parameter) {
+
+    ValidatedProviderPlugin validatedProviderPlugin =
+        pluginsManager.validatedProvider(context.getDocumentationContext().getDocumentationType());
+    return validatedProviderPlugin.validationFor(parameter);
   }
 }

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/OperationResponseClassReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/OperationResponseClassReader.java
@@ -29,6 +29,7 @@ import springfox.documentation.schema.TypeNameExtractor;
 import springfox.documentation.schema.plugins.SchemaPluginsManager;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.schema.EnumTypeDeterminer;
+import springfox.documentation.spi.schema.ValidatedProviderPlugin;
 import springfox.documentation.spi.schema.ViewProviderPlugin;
 import springfox.documentation.spi.schema.contexts.ModelContext;
 import springfox.documentation.spi.service.OperationBuilderPlugin;
@@ -67,9 +68,12 @@ public class OperationResponseClassReader implements OperationBuilderPlugin {
     ViewProviderPlugin viewProvider = 
         pluginsManager.viewProvider(context.getDocumentationContext().getDocumentationType());
 
+    ValidatedProviderPlugin validatedProviderPlugin =
+        pluginsManager.validatedProvider(context.getDocumentationContext().getDocumentationType());
+
     ModelContext modelContext = context.operationModelsBuilder().addReturn(
         returnType,
-        viewProvider.viewFor(context));
+        viewProvider.viewFor(context), validatedProviderPlugin.validationFor(context));
 
     Map<String, String> knownNames;
     knownNames = new HashMap<>();

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/ResponseMessagesReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/operation/ResponseMessagesReader.java
@@ -31,6 +31,7 @@ import springfox.documentation.schema.plugins.SchemaPluginsManager;
 import springfox.documentation.schema.property.ModelSpecificationFactory;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.schema.EnumTypeDeterminer;
+import springfox.documentation.spi.schema.ValidatedProviderPlugin;
 import springfox.documentation.spi.schema.ViewProviderPlugin;
 import springfox.documentation.spi.schema.contexts.ModelContext;
 import springfox.documentation.spi.service.OperationBuilderPlugin;
@@ -98,11 +99,14 @@ public class ResponseMessagesReader implements OperationBuilderPlugin {
     ViewProviderPlugin viewProvider =
         pluginsManager.viewProvider(context.getDocumentationContext().getDocumentationType());
 
+    ValidatedProviderPlugin validatedProviderPlugin =
+        pluginsManager.validatedProvider(context.getDocumentationContext().getDocumentationType());
+
     ResponseContext responseContext = new ResponseContext(context.getDocumentationContext(), context);
     if (!isVoid(returnType)) {
       ModelContext modelContext = context.operationModelsBuilder()
           .addReturn(returnType,
-              viewProvider.viewFor(context));
+              viewProvider.viewFor(context), validatedProviderPlugin.validationFor(context));
 
       Map<String, String> knownNames = new HashMap<>();
       Optional.ofNullable(context.getKnownModels().get(modelContext.getParameterId()))

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ParameterDataTypeReader.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/readers/parameter/ParameterDataTypeReader.java
@@ -39,6 +39,7 @@ import springfox.documentation.schema.property.ModelSpecificationFactory;
 import springfox.documentation.service.ResolvedMethodParameter;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.schema.EnumTypeDeterminer;
+import springfox.documentation.spi.schema.ValidatedProviderPlugin;
 import springfox.documentation.spi.schema.ViewProviderPlugin;
 import springfox.documentation.spi.schema.contexts.ModelContext;
 import springfox.documentation.spi.service.ParameterBuilderPlugin;
@@ -164,12 +165,16 @@ public class ParameterDataTypeReader implements ParameterBuilderPlugin {
         .viewProvider(context.getDocumentationContext()
             .getDocumentationType());
 
+    ValidatedProviderPlugin validatedProviderPlugin = pluginsManager
+        .validatedProvider(context.getDocumentationContext()
+            .getDocumentationType());
+
     return context.getOperationContext()
         .operationModelsBuilder()
         .addInputParam(
             parameterType,
             viewProvider.viewFor(methodParameter),
-            new HashSet<>());
+            validatedProviderPlugin.validationFor(methodParameter));
   }
 
   private boolean treatRequestParamAsString(ResolvedType parameterType) {

--- a/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/ModelSpecificationRegistryBuilder.java
+++ b/springfox-spring-web/src/main/java/springfox/documentation/spring/web/scanners/ModelSpecificationRegistryBuilder.java
@@ -287,10 +287,11 @@ public class ModelSpecificationRegistryBuilder {
 
     @Override
     public boolean hasRequestResponsePairs(ModelKey test) {
-      ModelKey other = test.flippedResponse();
-      return modelsLookupByKey.containsKey(other)
-          && !areEquivalent(test, other)
-          && !areEquivalent(other, test);
+      return modelsLookupByKey.keySet().stream().anyMatch(mk ->
+              Objects.equals(mk.getQualifiedModelName(), test.getQualifiedModelName())
+                      && mk.isResponse() != test.isResponse()
+                      && mk.getViewDiscriminator() == test.getViewDiscriminator()
+      );
     }
 
     private boolean areEquivalent(


### PR DESCRIPTION
Add support for groups of validations for 
Supported annotations:
- `@NotNull`
- `@Pattern`
- `@DecimalMin` and `@DecimalMax`
- `@Null`
- `@Max` and `@Min`
- `@NotBlank`
- `@Size`

- Add support for annotation containers, eg @Size.List

Remember that parameter `required` takes precedence over annotation `@NotNull`.
To increase the priority of annotation `@NotNull`, you need to redefine the plugin in the following way, specifying annotation `@Order` for plugin.
```
@Order
@Component
public class NotNullAnnotationPlugin extends springfox.bean.validators.plugins.schema.NotNullAnnotationPlugin {

}
```

The validation group applies to child objects and parameters.